### PR TITLE
fix: use setup node to force github workflow server to use node 16

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,6 +15,12 @@ jobs:
     steps:
       - name: Checkout commit
         uses: actions/checkout@v2
+      
+      - name: Set specified node version
+        uses: actions/setup-node@v3
+        with:
+          # Necessary because of npm strict-engine flag
+          node-version: ${{ env.NODE_VERSION }}
 
       - name: Install node modules
         run: npm ci

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,7 +19,6 @@ jobs:
       - name: Set specified node version
         uses: actions/setup-node@v3
         with:
-          # Necessary because of npm strict-engine flag
           node-version: ${{ env.NODE_VERSION }}
 
       - name: Install node modules


### PR DESCRIPTION
## Problem

The deployment from the most recent PR merge into master branch #87 caused a bug in the GitHub workflow. 

Previously it was thought to be caused by changes in the engine rules in `package.json` and `.npmrc`.

Upon further investigation, the root cause turns out to be a Github specific bug instead of our own code changes. Specifically, one of our main dependency, `openid-client-5.1.5`, has an engine rule that did not account for the inclusion of Node 18, which was very recent at the point of release:
![image](https://user-images.githubusercontent.com/47116462/231651340-8c0ba482-a0ae-4057-b0ed-16e3388a5145.png)

Therefore, the deployment would fail if the server running the deployment is using Node18. As a result of Github possibly having upgraded (some of) their servers' node versions, the `npm ci` command in our workflow might or might not run successfully, depending on the Github server's node versioning.

Closes #88.

## Solution

The use of `setup-node` Github Action to ensure that the jobs are always run in the same version as the our app's intended node version.

**Improvements**:

Suggestion: Upgrade the version of `openid-client` to the newest release, which does not have an engine check rule anymore. More generally, upgrading our dependencies in a separate PR might be a good idea since it has been 5 months since the last update.

## Before & After Screenshots

**BEFORE**:
![image](https://user-images.githubusercontent.com/47116462/231654222-ea2843ed-1ff9-417e-9730-ad5d741f8a22.png)

**AFTER**:
![image](https://user-images.githubusercontent.com/47116462/231654459-56d57da8-0f4c-48ce-9912-86a8f886b598.png)


## Tests

The deployment workflow has been tested twice in the test branch `test/upgrade_node_version`, and both deployments exited successfully. 

However, note that since the target platform is the outdated Elastic Beanstalk platform that does not support node 16, it has not been verified that it will run properly on EB. The reason we can still proceed is that EB would automatically roll back on the previous working version, so there is minimal risk even if something goes wrong.

It has been verified in the logs that Node version 16.16 is being explicitly used:
![image](https://user-images.githubusercontent.com/47116462/231654706-04689f5c-7642-456f-9c33-7fe94aa1501c.png)


## Deploy Notes

**New Actions**:

- `setup-node` : Used to set node version as the same as the environment's node version.

