### PR TITLE
(WIP) feat: upgrade SgidClient service to use PKCE and new functions

### DIFF
--- a/lib/sgid-client.service.js
+++ b/lib/sgid-client.service.js
@@ -1,4 +1,4 @@
-const { SgidClient } = require('@opengovsg/sgid-client')
+const { SgidClient, generatePkcePair } = require('@opengovsg/sgid-client')
 const config = require('../lib/config')
 const randomnonce = 'randomnonce'
 const scopes = process.env.SCOPES
@@ -12,6 +12,7 @@ class SgidService {
       redirectUri: redirectUri,
       hostname: hostname,
     })
+    this.codeVerifier = ''
   }
 
   /**
@@ -26,7 +27,14 @@ class SgidService {
     if (!env || !scopes || !nonce)
       throw Error(`env, scopes, nonce cannot be empty`)
     try {
-      const { url } = this.sgidClient.authorizationUrl(env, scopes, nonce)
+      const { codeChallenge, codeVerifier } = generatePkcePair()
+      this.codeVerifier = codeVerifier
+      const { url } = this.sgidClient.authorizationUrl({
+        state: env,
+        scope: scopes,
+        nonce,
+        codeChallenge,
+      })
       return { url }
     } catch (e) {
       console.error(e)
@@ -38,15 +46,17 @@ class SgidService {
    * Fetches the token via sgid SDK
    *
    * @param {string} code
+   * @param {string} randomnonce
    * @returns {object} { sub: string, accessToken: string }
    */
-  async callback(code) {
+  async callback(code, randomnonce) {
     if (!code) throw Error(`code cannot be empty`)
     try {
-      const { sub, accessToken } = await this.sgidClient.callback(
+      const { sub, accessToken } = await this.sgidClient.callback({
         code,
-        randomnonce
-      )
+        nonce: randomnonce,
+        codeVerifier: this.codeVerifier,
+      })
       return { sub, accessToken: accessToken }
     } catch (e) {
       console.error(e)
@@ -63,7 +73,7 @@ class SgidService {
   async userinfo(accessToken) {
     if (!accessToken) throw Error(`accessToken cannot be empty`)
     try {
-      return await this.sgidClient.userinfo(accessToken)
+      return await this.sgidClient.userinfo({ accessToken })
     } catch (e) {
       console.error(e)
       throw new Error('Error retrieving user info via sgid-client')


### PR DESCRIPTION
## Problem

As part of our effort to make PKCE mandatory for all clients ([issue here](https://github.com/datagovsg/sgid-server/issues/244)), we are rolling out changes in `sgid-server` and our Node.js SDK `sgid-client`. Part of that effort involves upgrading our Demo app to use the new SDK to integrate PKCE.

Closes #86 (Project board issue found [here](https://github.com/orgs/datagovsg/projects/43/views/1?filterQuery=update&pane=issue&itemId=25426298))

## Solution

As we have a `sgid-client.service.js` wrapper over our SDK, we simply need to update how this service utilizes the v2 SDK without modifying how the test app itself interfaces with the service.

**Features**:
- Add a `codeVerifier` attribute to store the `codeVerifier` for each instance of the SgidClient
- Update the function calls to the SDK to use object params instead of sequential params
- Generate the PKCE pair in the service's `authorizationUrl` function
- Pass the `codeChallenge` into the SDK's `authorizationUrl` function
- Pass the `codeVerifier` into the SDK's `callback` function

**Bug Fixes**:
- Added the `randomnonce` parameter to the service's `callback` function because the `callback` route was passing it to the function (even though the function is not receiving it)

## Tests

Tested against staging server (as the PKCE changes are not live on production yet) by
- changing `.env` variables to use a staging client. 
- pointing to a local version of the SDK (i.e. `npm link`) => once the SDK is merged to develop, point the test app to the build files and deploy for testing

https://github.com/opengovsg/sgid-test-app/assets/63008910/e813a8fb-4819-4e97-a7e7-6bf1d2c58167


**New dependencies**:

- `@opengovsg/sgid-client` : Updated the SDK
