### PR TITLE
feat: split prod and staging scopes to allow granular testing

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,6 +3,7 @@ PORT=10000
 CLIENT_ID="123"
 CLIENT_SECRET="123"
 SCOPES="openid myinfo.name myinfo.passport_expiry_date myinfo.nric_number"
+DEV_AND_STAGING_SCOPES="openid sgidthirdpartymock.work_email sgidthirdpartymock.is_public_officer myinfo.nric_number myinfo.name myinfo.email myinfo.mobile_number"
 PRIVATE_KEY="-----BEGIN RSA PRIVATE KEY-----woot woot-----END RSA PRIVATE KEY-----"
 OVERRIDE_DEV="http://localhost:3000"
 

--- a/config/index.ts
+++ b/config/index.ts
@@ -5,3 +5,5 @@ export const BASE_URLS = {
 }
 export const PORT = process.env.PORT || 10000
 export const SCOPES = process.env.SCOPES || 'openid'
+export const DEV_AND_STAGING_SCOPES =
+  process.env.DEV_AND_STAGING_SCOPES || 'openid'

--- a/routes/home.ts
+++ b/routes/home.ts
@@ -1,6 +1,6 @@
 import express from 'express'
 import { v4 as uuidV4 } from 'uuid'
-import { BASE_URLS, SCOPES } from '../config'
+import { BASE_URLS, SCOPES, DEV_AND_STAGING_SCOPES } from '../config'
 import { generatePkcePair } from '@opengovsg/sgid-client'
 import { sgidService } from '../services/sgid-client.service'
 import { nodeCache } from '../services/node-cache.service'
@@ -20,7 +20,7 @@ export const home = (req: express.Request, res: express.Response) => {
   Object.keys(BASE_URLS).forEach((env) => {
     const { url, nonce } = sgidService[env].authorizationUrl(
       env,
-      SCOPES,
+      env === 'prod' ? SCOPES : DEV_AND_STAGING_SCOPES,
       codeChallenge
     )
     authUrl[env] = url


### PR DESCRIPTION
## Context

Demo app uses `SCOPES` env var for both prod and staging.

## Problem

Prod and staging should not have the same scopes since we would want to test all third party data sources in staging but not prod.

## Solution

Add another env var calls `DEV_AND_STAGING_SCOPES` and have `routes/home.ts` to use the following code.
```
export const home = (req: express.Request, res: express.Response) => {
  const sessionId = uuidV4()

  const { codeChallenge, codeVerifier } = generatePkcePair()

  const authUrl: { [index: string]: string } = {}
  const authNonce: { [index: string]: string } = {}
  Object.keys(BASE_URLS).forEach((env) => {
    const { url, nonce } = sgidService[env].authorizationUrl(
      env,
      env !== 'prod' ? DEV_AND_STAGING_SCOPES : SCOPES,
      codeChallenge
    )
    authUrl[env] = url
    if (nonce) {
      authNonce[env] = nonce
    }
  })

  nodeCache.set<IAuthSession>(sessionId, { codeVerifier, authNonce })

  res.cookie(SESSION_COOKIE_NAME, sessionId, { httpOnly: true })
  res.render('index', { authUrl })
}
```

## New Env Var
`DEV_AND_STAGING_SCOPES`
